### PR TITLE
update twitterfix

### DIFF
--- a/twitterfix/twitterfix.py
+++ b/twitterfix/twitterfix.py
@@ -364,9 +364,13 @@ class TwitterFix(commands.Cog):
                                 if title_match:
                                     structured_output["thread-title"] = title_match.group(1)
                                 if summary_match:
-                                    # Handle escaped quotes and newlines in summary
+                                    # Handle all standard escape sequences in summary
                                     summary = summary_match.group(1)
-                                    summary = summary.replace(r'\"', '"').replace(r'\n', '\n')
+                                    try:
+                                        summary = _json.loads(f'"{summary}"')
+                                    except Exception:
+                                        # Fallback to original if decoding fails
+                                        pass
                                     structured_output["thread-summary"] = summary
                                 log.info(f"Extracted data using regex fallback: {structured_output}")
                                 return structured_output

--- a/twitterfix/twitterfix.py
+++ b/twitterfix/twitterfix.py
@@ -327,12 +327,51 @@ class TwitterFix(commands.Cog):
                             log.error(f"OpenRouter response missing expected content structure. Result: {result}")
                             return None
                         import json as _json # Keep import local if only used here
+                        import re as _re
+                        
+                        # Try direct JSON parsing first
                         try:
                             structured_output = _json.loads(content_str)
                             log.debug(f"OpenRouter API success, got: {structured_output}")
                             return structured_output
-                        except _json.JSONDecodeError as json_e:
-                            log.error(f"Failed to decode JSON from OpenRouter response: {json_e}. Content was: {content_str}")
+                        except _json.JSONDecodeError:
+                            # If direct parsing fails, try to extract JSON from markdown code blocks
+                            log.debug(f"Direct JSON parsing failed, attempting to extract from markdown")
+                            
+                            # Pattern to match JSON in markdown code blocks
+                            json_pattern = _re.compile(r'```(?:json)?\s*(\{[^`]+\})\s*```', _re.DOTALL)
+                            match = json_pattern.search(content_str)
+                            
+                            if match:
+                                json_str = match.group(1)
+                                try:
+                                    structured_output = _json.loads(json_str)
+                                    log.debug(f"Successfully extracted JSON from markdown: {structured_output}")
+                                    return structured_output
+                                except _json.JSONDecodeError:
+                                    log.debug(f"Failed to parse extracted JSON, trying fallback")
+                            
+                            # Fallback: Try to extract thread-title and thread-summary using regex
+                            # This handles malformed JSON or partial responses
+                            title_pattern = _re.compile(r'"thread-title"\s*:\s*"([^"]+)"')
+                            summary_pattern = _re.compile(r'"thread-summary"\s*:\s*"([^"]+)"', _re.DOTALL)
+                            
+                            title_match = title_pattern.search(content_str)
+                            summary_match = summary_pattern.search(content_str)
+                            
+                            if title_match or summary_match:
+                                structured_output = {}
+                                if title_match:
+                                    structured_output["thread-title"] = title_match.group(1)
+                                if summary_match:
+                                    # Handle escaped quotes and newlines in summary
+                                    summary = summary_match.group(1)
+                                    summary = summary.replace(r'\"', '"').replace(r'\n', '\n')
+                                    structured_output["thread-summary"] = summary
+                                log.info(f"Extracted data using regex fallback: {structured_output}")
+                                return structured_output
+                            
+                            log.error(f"Failed to decode JSON from OpenRouter response. Content was: {content_str}")
                             return None
                     else:
                         error_text = await resp.text()


### PR DESCRIPTION
claude chatlogs remain local, fix malformed json response handling

## Summary by Sourcery

Improve JSON response handling in call_openrouter by adding fallback parsing strategies for malformed content

Bug Fixes:
- Handle JSONDecodeError more robustly by attempting extraction from Markdown code fences

Enhancements:
- Add regex-based fallback to extract thread-title and thread-summary when JSON parsing fails