### PR TITLE
feat(twitterfix): better X article detection and fxtwitter handlingDetect X article URLs and improve fetching/rendering of article contentfrom fxtwitter. Add URL parsing helper and a regex for X article links(i/article/<id>) so xcancel-proxied posts can be resolved. Provide adefault User-Agent header for HTTP requests to improve API responses.

### DIFF
--- a/twitterfix/pyproject.toml
+++ b/twitterfix/pyproject.toml
@@ -3,5 +3,5 @@ name = "twitter-fix"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = []

--- a/twitterfix/test_twitterfix.py
+++ b/twitterfix/test_twitterfix.py
@@ -1,0 +1,116 @@
+"""ABOUTME: Tests TwitterFix article rendering and fallback fetch helpers.
+ABOUTME: Stubs Discord and Redbot imports so helper logic can run standalone."""
+
+import sys
+import types
+import unittest
+from importlib import util
+from pathlib import Path
+
+
+def command_decorator(*_args, **_kwargs):
+    def decorate(func):
+        func.command = command_decorator
+        func.group = command_decorator
+        return func
+
+    return decorate
+
+
+class Cog:
+    @staticmethod
+    def listener():
+        return command_decorator()
+
+
+class TextChannel:
+    pass
+
+
+class Message:
+    pass
+
+
+def install_import_stubs():
+    discord = types.ModuleType("discord")
+    discord.Embed = object
+    discord.Message = Message
+    discord.TextChannel = TextChannel
+    aiohttp = types.ModuleType("aiohttp")
+    aiohttp.ClientConnectorError = Exception
+
+    commands = types.ModuleType("commands")
+    commands.Cog = Cog
+    commands.Context = object
+    commands.group = command_decorator
+    commands.guild_only = command_decorator
+
+    checks = types.ModuleType("checks")
+    checks.admin_or_permissions = command_decorator
+
+    config = types.SimpleNamespace(get_conf=lambda *_args, **_kwargs: None)
+    bot = types.ModuleType("bot")
+    bot.Red = object
+
+    chat_formatting = types.ModuleType("chat_formatting")
+    chat_formatting.box = lambda value: value
+
+    redbot = types.ModuleType("redbot")
+    core = types.ModuleType("core")
+    core.commands = commands
+    core.Config = config
+    core.checks = checks
+    core.bot = bot
+    utils = types.ModuleType("utils")
+    utils.chat_formatting = chat_formatting
+    core.utils = utils
+    redbot.core = core
+
+    sys.modules.setdefault("discord", discord)
+    sys.modules.setdefault("aiohttp", aiohttp)
+    sys.modules.setdefault("redbot", redbot)
+    sys.modules.setdefault("redbot.core", core)
+    sys.modules.setdefault("redbot.core.commands", commands)
+    sys.modules.setdefault("redbot.core.checks", checks)
+    sys.modules.setdefault("redbot.core.bot", bot)
+    sys.modules.setdefault("redbot.core.utils", utils)
+    sys.modules.setdefault("redbot.core.utils.chat_formatting", chat_formatting)
+
+
+def load_twitterfix_module():
+    install_import_stubs()
+    module_path = Path(__file__).with_name("twitterfix.py")
+    spec = util.spec_from_file_location("twitterfix_module", module_path)
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TwitterFixArticleReaderTests(unittest.IsolatedAsyncioTestCase):
+    async def test_article_reader_fetch_uses_detected_article_url_path(self):
+        module = load_twitterfix_module()
+        cog = module.TwitterFix.__new__(module.TwitterFix)
+        requested_urls = []
+
+        async def poll_markdown(url):
+            requested_urls.append(url)
+            return "article body"
+
+        cog.poll_markdown = poll_markdown
+
+        result = await cog.fetch_x_article_reader_markdown(
+            "https://x.com/example/status/12345",
+            "https://x.com/i/article/98765",
+        )
+
+        self.assertEqual(
+            requested_urls,
+            ["https://r.jina.ai/http://x-reader.val.run/i/article/98765"],
+        )
+        self.assertIn("Original post: https://x.com/example/status/12345", result)
+        self.assertIn("Article URL: https://x.com/i/article/98765", result)
+        self.assertIn("article body", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twitterfix/test_twitterfix.py
+++ b/twitterfix/test_twitterfix.py
@@ -87,7 +87,7 @@ def load_twitterfix_module():
 
 
 class TwitterFixArticleReaderTests(unittest.IsolatedAsyncioTestCase):
-    async def test_article_reader_fetch_uses_detected_article_url_path(self):
+    async def test_article_reader_fetch_uses_original_status_url_path(self):
         module = load_twitterfix_module()
         cog = module.TwitterFix.__new__(module.TwitterFix)
         requested_urls = []
@@ -105,7 +105,7 @@ class TwitterFixArticleReaderTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             requested_urls,
-            ["https://r.jina.ai/http://x-reader.val.run/i/article/98765"],
+            ["https://r.jina.ai/http://x-reader.val.run/example/status/12345"],
         )
         self.assertIn("Original post: https://x.com/example/status/12345", result)
         self.assertIn("Article URL: https://x.com/i/article/98765", result)

--- a/twitterfix/twitterfix.py
+++ b/twitterfix/twitterfix.py
@@ -1,6 +1,7 @@
 import re
 import json
 from typing import Literal, Optional, NoReturn
+from urllib.parse import urlsplit
 import discord
 from redbot.core import commands, Config, checks
 from redbot.core.bot import Red
@@ -21,6 +22,14 @@ DEFAULT_GUILD = {
 }
 
 XCOM_REGEX = re.compile(r"https://x\.com/[^\s]+", re.IGNORECASE)
+XCANCEL_ARTICLE_REGEX = re.compile(r"https://x\.com/i/article/\d+", re.IGNORECASE)
+DEFAULT_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/133.0.0.0 Safari/537.36"
+    )
+}
 
 class TwitterFix(commands.Cog):
     """
@@ -214,6 +223,12 @@ class TwitterFix(commands.Cog):
 
             # --- Fetch tweet content: try fxtwitter API first (fast), fall back to Jina ---
             markdown_content = await self.fetch_fxtwitter(x_url)
+
+            if not markdown_content:
+                article_url = await self.find_xcancel_article_url(xcancel_url)
+                if article_url:
+                    log.info(f"Detected X article via xcancel for {x_url}: {article_url}")
+                    markdown_content = await self.fetch_x_article_reader_markdown(x_url, article_url)
             
             if not markdown_content:
                 log.info(f"fxtwitter failed, trying Jina fallback for {x_url}")
@@ -278,18 +293,36 @@ class TwitterFix(commands.Cog):
         
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.get(api_url, timeout=15) as resp:
+                async with session.get(api_url, timeout=15, headers=DEFAULT_HEADERS) as resp:
                     if resp.status == 200:
                         data = await resp.json()
                         tweet = data.get("tweet", {})
                         if not tweet:
                             log.warning(f"fxtwitter API returned no tweet data for {api_url}")
                             return None
+
+                        article_markdown = self.render_fxtwitter_article(tweet)
+                        if article_markdown:
+                            author = tweet.get("author", {})
+                            log.info(
+                                "Successfully fetched article content from fxtwitter: @%s",
+                                author.get("screen_name", "unknown"),
+                            )
+                            return article_markdown
                         
                         author = tweet.get("author", {})
                         author_name = author.get("name", "Unknown")
                         author_handle = author.get("screen_name", "unknown")
                         text = tweet.get("text", "")
+                        if not text:
+                            raw_text = tweet.get("raw_text", {})
+                            if isinstance(raw_text, dict):
+                                raw_text_value = raw_text.get("text", "")
+                                if raw_text_value and not raw_text_value.startswith("https://t.co/"):
+                                    text = raw_text_value
+                        if not text.strip():
+                            log.info(f"fxtwitter returned no usable tweet text for {api_url}")
+                            return None
                         likes = tweet.get("likes", 0)
                         retweets = tweet.get("retweets", 0)
                         replies = tweet.get("replies", 0)
@@ -320,9 +353,171 @@ class TwitterFix(commands.Cog):
             log.warning(f"fxtwitter API error for {api_url}: {e}")
         return None
 
+    def render_fxtwitter_article(self, tweet: dict) -> Optional[str]:
+        article = tweet.get("article") or {}
+        content = article.get("content") or {}
+        blocks = content.get("blocks") or []
+        title = (article.get("title") or "").strip()
+        preview_text = (article.get("preview_text") or "").strip()
+        if not title and not preview_text and not blocks:
+            return None
+
+        author = tweet.get("author", {})
+        author_name = author.get("name", "Unknown")
+        author_handle = author.get("screen_name", "unknown")
+        article_id = article.get("id")
+        article_url = f"https://x.com/i/article/{article_id}" if article_id else None
+        body = self.render_x_article_blocks(content, article.get("media_entities") or [])
+        likes = tweet.get("likes", 0)
+        retweets = tweet.get("retweets", 0)
+        replies = tweet.get("replies", 0)
+        views = tweet.get("views", 0)
+        created_at = tweet.get("created_at", "")
+
+        content_parts = [f"# X Article by @{author_handle} ({author_name})"]
+        if title:
+            content_parts.append(f"\n## {title}")
+        if preview_text and not body.startswith(preview_text):
+            content_parts.append(f"\n{preview_text}")
+        if body:
+            content_parts.append(f"\n{body}")
+        if article_url:
+            content_parts.append(f"\nArticle URL: {article_url}")
+        content_parts.append(f"\nOriginal post: {tweet.get('url', '')}")
+        content_parts.append(f"\n---\n💬 {replies} | 🔁 {retweets} | ❤️ {likes} | 👁️ {views}")
+        if created_at:
+            content_parts.append(f"\n📅 {created_at}")
+        return "\n".join(part for part in content_parts if part)
+
+    def render_x_article_blocks(self, content: dict, media_entities: list[dict]) -> str:
+        entity_lookup = self.build_entity_lookup(content.get("entityMap") or [])
+        media_lookup = self.build_media_lookup(media_entities)
+        rendered_blocks: list[str] = []
+
+        for block in content.get("blocks") or []:
+            block_type = block.get("type", "unstyled")
+            raw_text = block.get("text", "")
+            text = self.apply_article_entities(raw_text, block.get("entityRanges") or [], entity_lookup).strip()
+            if block_type == "atomic":
+                media_markdown = self.render_article_media_block(block, entity_lookup, media_lookup)
+                if media_markdown:
+                    rendered_blocks.append(media_markdown)
+                continue
+            if not text:
+                continue
+
+            if block_type == "header-one":
+                rendered_blocks.append(f"# {text}")
+            elif block_type == "header-two":
+                rendered_blocks.append(f"## {text}")
+            elif block_type == "header-three":
+                rendered_blocks.append(f"### {text}")
+            elif block_type == "unordered-list-item":
+                rendered_blocks.append(f"- {text}")
+            elif block_type == "ordered-list-item":
+                rendered_blocks.append(f"1. {text}")
+            elif block_type == "blockquote":
+                rendered_blocks.append(f"> {text}")
+            else:
+                rendered_blocks.append(text)
+
+        return "\n\n".join(rendered_blocks)
+
+    def build_entity_lookup(self, entity_map: list | dict) -> dict[str, dict]:
+        if isinstance(entity_map, dict):
+            return {str(key): value for key, value in entity_map.items()}
+        lookup = {}
+        for item in entity_map:
+            if not isinstance(item, dict):
+                continue
+            key = item.get("key")
+            value = item.get("value")
+            if key is not None and isinstance(value, dict):
+                lookup[str(key)] = value
+        return lookup
+
+    def build_media_lookup(self, media_entities: list[dict]) -> dict[str, str]:
+        lookup = {}
+        for media in media_entities:
+            if not isinstance(media, dict):
+                continue
+            media_id = str(media.get("media_id", ""))
+            media_info = media.get("media_info") or {}
+            original_img_url = media_info.get("original_img_url")
+            if media_id and original_img_url:
+                lookup[media_id] = original_img_url
+        return lookup
+
+    def apply_article_entities(self, text: str, entity_ranges: list[dict], entity_lookup: dict[str, dict]) -> str:
+        rendered = text
+        for entity_range in sorted(entity_ranges, key=lambda item: item.get("offset", 0), reverse=True):
+            offset = entity_range.get("offset", 0)
+            length = entity_range.get("length", 0)
+            key = str(entity_range.get("key"))
+            entity = entity_lookup.get(key) or {}
+            entity_type = entity.get("type")
+            entity_data = entity.get("data") or {}
+            span = rendered[offset:offset + length]
+            replacement = span
+            if entity_type == "LINK" and entity_data.get("url"):
+                replacement = f"[{span}]({entity_data['url']})"
+            rendered = rendered[:offset] + replacement + rendered[offset + length:]
+        return rendered
+
+    def render_article_media_block(
+        self,
+        block: dict,
+        entity_lookup: dict[str, dict],
+        media_lookup: dict[str, str],
+    ) -> Optional[str]:
+        for entity_range in block.get("entityRanges") or []:
+            key = str(entity_range.get("key"))
+            entity = entity_lookup.get(key) or {}
+            if entity.get("type") != "MEDIA":
+                continue
+            media_items = (entity.get("data") or {}).get("mediaItems") or []
+            urls = []
+            for media_item in media_items:
+                media_id = str(media_item.get("mediaId", ""))
+                media_url = media_lookup.get(media_id)
+                if media_url:
+                    urls.append(media_url)
+            if urls:
+                return "\n".join(f"![Article image]({url})" for url in urls)
+        return None
+
+    async def find_xcancel_article_url(self, xcancel_url: str) -> Optional[str]:
+        try:
+            async with aiohttp.ClientSession(headers=DEFAULT_HEADERS) as session:
+                async with session.get(xcancel_url, timeout=15, allow_redirects=True) as resp:
+                    text = await resp.text()
+                    match = XCANCEL_ARTICLE_REGEX.search(text)
+                    if match:
+                        return match.group(0)
+                    if "Verifying your request" in text:
+                        log.debug(f"xcancel anti-bot page blocked article detection for {xcancel_url}")
+        except asyncio.TimeoutError:
+            log.warning(f"xcancel article detection timed out for {xcancel_url}")
+        except Exception as e:
+            log.warning(f"xcancel article detection failed for {xcancel_url}: {e}")
+        return None
+
+    async def fetch_x_article_reader_markdown(self, x_url: str, article_url: str) -> Optional[str]:
+        path = urlsplit(x_url).path.lstrip("/")
+        markdown_url = f"https://r.jina.ai/http://x-reader.val.run/{path}"
+        markdown_content = await self.poll_markdown(markdown_url)
+        if not markdown_content:
+            return None
+        return (
+            "# X Article\n\n"
+            f"Original post: {x_url}\n"
+            f"Article URL: {article_url}\n\n"
+            f"{markdown_content}"
+        )
+
     async def poll_markdown(self, url: str, max_attempts: int = 10, delay: float = 2.0) -> Optional[str]:
         """Poll the r.jina.ai URL for markdown content, return as string if found."""
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(headers=DEFAULT_HEADERS) as session:
             for attempt in range(max_attempts):
                 try:
                     log.debug(f"poll_markdown attempt {attempt + 1} for {url}")

--- a/twitterfix/twitterfix.py
+++ b/twitterfix/twitterfix.py
@@ -506,7 +506,7 @@ class TwitterFix(commands.Cog):
         return None
 
     async def fetch_x_article_reader_markdown(self, x_url: str, article_url: str) -> Optional[str]:
-        path = urlsplit(article_url).path.lstrip("/")
+        path = urlsplit(x_url).path.lstrip("/")
         markdown_url = f"https://r.jina.ai/http://x-reader.val.run/{path}"
         markdown_content = await self.poll_markdown(markdown_url)
         if not markdown_content:

--- a/twitterfix/twitterfix.py
+++ b/twitterfix/twitterfix.py
@@ -1,3 +1,6 @@
+"""ABOUTME: Discord cog that expands X/Twitter links into discussion threads.
+ABOUTME: Fetches tweet/article markdown and summarizes it through OpenRouter."""
+
 import re
 import json
 from typing import Literal, Optional, NoReturn
@@ -503,7 +506,7 @@ class TwitterFix(commands.Cog):
         return None
 
     async def fetch_x_article_reader_markdown(self, x_url: str, article_url: str) -> Optional[str]:
-        path = urlsplit(x_url).path.lstrip("/")
+        path = urlsplit(article_url).path.lstrip("/")
         markdown_url = f"https://r.jina.ai/http://x-reader.val.run/{path}"
         markdown_content = await self.poll_markdown(markdown_url)
         if not markdown_content:


### PR DESCRIPTION
Enhance fxtwitter client:
- send DEFAULT_HEADERS on requests- handle and prefer article payloads returned by fxtwitter via render_fxtwitter_article()
- attempt to extract usable text from nested raw_text when text is empty- early-return when no usable content is present and log accordinglyAdd helpers to locate xcancel article URLs and render article blocks,
and wire article fallback: if fxtwitter markdown is empty, try findingan xcancel article URL and fetch article reader markdown.

Fixes missing return on error paths and increases logging to aiddiagnosis when fxtwitter or article extraction fails.

## Summary by Sourcery

Improve X/Twitter content handling by preferring rich article data when available, adding an xcancel-based article fallback, and standardizing HTTP request headers for more reliable API responses.

New Features:
- Add support for rendering X article content from fxtwitter article payloads into markdown, including text, headings, links, and media.
- Introduce detection of X article URLs via xcancel pages and a fallback path to fetch article reader markdown when fxtwitter markdown is empty.

Bug Fixes:
- Ensure early returns on error paths when no usable fxtwitter content is available, avoiding downstream processing of empty data.

Enhancements:
- Apply a default browser-like User-Agent header to outbound aiohttp requests to improve compatibility with external APIs and pages.
- Enhance tweet text extraction by falling back to nested raw_text when the main text field is empty and skipping non-usable link-only content.
- Improve logging around fxtwitter failures, missing tweet text, and xcancel anti-bot behavior to aid debugging.